### PR TITLE
[BUGFIX] Get the Travis builds green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,8 @@ before_install:
 
 install:
   - composer install
+
+script:
+  - >
+    echo;
+    echo "Nothing to do yet.";


### PR DESCRIPTION
As there are not real build tasks yet, we'll need an empty task to keep
Travis from using its default task (which would break the build).