### PR TITLE
[BUGFIX] Return HTTP status 400 on bad client data instead of 500

### DIFF
--- a/Classes/Controller/SessionController.php
+++ b/Classes/Controller/SessionController.php
@@ -129,7 +129,7 @@ class SessionController extends Controller
         }
 
         if (!$isValid) {
-            $response->setStatusCode(500);
+            $response->setStatusCode(400);
             $response->setContent(json_encode($responseContent, JSON_NUMERIC_CHECK | JSON_PRETTY_PRINT));
         }
 

--- a/Documentation/Api/RestApi.apib
+++ b/Documentation/Api/RestApi.apib
@@ -38,6 +38,36 @@ that require authentication.
             "expiry": "2017-07-20T18:22:48+00:00"
         }
 
++ Response 400 (application/json)
+
+    + Body
+
+        {
+            "code": 1500559729794,
+            "message": "No data",
+            "description": "The request does not contain any data."
+        }
+
++ Response 400 (application/json)
+
+    + Body
+
+        {
+            "code": 1500562402438,
+            "message": "Invalid JSON data",
+            "description": "The data in the request is invalid JSON."
+        }
+
++ Response 400 (application/json)
+
+    + Body
+
+        {
+            "code": 1500562647846,
+            "message": "Incomplete credentials",
+            "description": "The request does not contain both loginName and password."
+        }
+
 + Response 401 (application/json)
 
     + Body

--- a/Tests/Integration/Controller/SessionControllerTest.php
+++ b/Tests/Integration/Controller/SessionControllerTest.php
@@ -56,14 +56,14 @@ class SessionControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function postSessionsWithNoJsonReturnsError500()
+    public function postSessionsWithNoJsonReturnsError400()
     {
         $this->client->request('post', '/api/v2/sessions');
 
         $responseContent = $this->client->getResponse()->getContent();
         $parsedResponseContent = json_decode($responseContent, true);
 
-        self::assertSame(500, $this->client->getResponse()->getStatusCode());
+        self::assertSame(400, $this->client->getResponse()->getStatusCode());
         self::assertSame(
             [
                 'code' => 1500559729794,
@@ -77,14 +77,14 @@ class SessionControllerTest extends AbstractControllerTest
     /**
      * @test
      */
-    public function postSessionsWithInvalidJsonReturnsError500()
+    public function postSessionsWithInvalidJsonReturnsError400()
     {
         $this->client->request('post', '/api/v2/sessions', [], [], [], 'Here be dragons, but no JSON.');
 
         $responseContent = $this->client->getResponse()->getContent();
         $parsedResponseContent = json_decode($responseContent, true);
 
-        self::assertSame(500, $this->client->getResponse()->getStatusCode());
+        self::assertSame(400, $this->client->getResponse()->getStatusCode());
         self::assertSame(
             [
                 'code' => 1500562402438,
@@ -112,14 +112,14 @@ class SessionControllerTest extends AbstractControllerTest
      * @param string $jsonData
      * @dataProvider incompleteCredentialsDataProvider
      */
-    public function postSessionsWithValidIncompleteJsonReturnsError500(string $jsonData)
+    public function postSessionsWithValidIncompleteJsonReturnsError400(string $jsonData)
     {
         $this->client->request('post', '/api/v2/sessions', [], [], [], $jsonData);
 
         $responseContent = $this->client->getResponse()->getContent();
         $parsedResponseContent = json_decode($responseContent, true);
 
-        self::assertSame(500, $this->client->getResponse()->getStatusCode());
+        self::assertSame(400, $this->client->getResponse()->getStatusCode());
         self::assertSame(
             [
                 'code' => 1500562647846,


### PR DESCRIPTION
Now the status code correctly signifies that the problem is with the data
provided by the client, not some problem on the server side.