### PR TITLE
[FEATURE] Add the Symfony console and the public web/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /.idea/
 /.project
 /.webprj
+/bin/
 /composer.lock
 /nbproject
 /vendor/
+/web/

--- a/Tests/Integration/Composer/ScriptsTest.php
+++ b/Tests/Integration/Composer/ScriptsTest.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\RestBundle\Tests\Integration\Composer;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testcase.
+ *
+ * @author Oliver Klee <oliver@phplist.com>
+ */
+class ScriptsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function webDirectoryHasBeenCreated()
+    {
+        self::assertDirectoryExists($this->getAbsoluteWebDirectoryPath());
+    }
+
+    /**
+     * @return string
+     */
+    private function getAbsoluteWebDirectoryPath(): string
+    {
+        return dirname(__DIR__, 3) . '/web/';
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function webDirectoryFilesDataProvider(): array
+    {
+        return [
+            'production entry point' => ['app.php'],
+            'development entry point' => ['app_dev.php'],
+            'testing entry point' => ['app_test.php'],
+            '.htaccess' => ['.htaccess'],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $fileName
+     * @dataProvider webDirectoryFilesDataProvider
+     */
+    public function webDirectoryFilesExist(string $fileName)
+    {
+        self::assertFileExists($this->getAbsoluteWebDirectoryPath() . $fileName);
+    }
+
+    /**
+     * @test
+     */
+    public function binariesDirectoryHasBeenCreated()
+    {
+        self::assertDirectoryExists($this->getAbsoluteBinariesDirectoryPath());
+    }
+
+    /**
+     * @return string
+     */
+    private function getAbsoluteBinariesDirectoryPath(): string
+    {
+        return dirname(__DIR__, 3) . '/bin/';
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function binariesDataProvider(): array
+    {
+        return [
+            'Symfony console' => ['console'],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $fileName
+     * @dataProvider binariesDataProvider
+     */
+    public function binariesExist(string $fileName)
+    {
+        self::assertFileExists($this->getAbsoluteBinariesDirectoryPath() . $fileName);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,22 @@
             "PhpList\\RestBundle\\Tests\\": "Tests/"
         }
     },
+    "scripts": {
+        "binaries": [
+            "PhpList\\PhpList4\\Composer\\ScriptHandler::createBinaries"
+        ],
+        "document-root": [
+            "PhpList\\PhpList4\\Composer\\ScriptHandler::createPublicWebDirectory"
+        ],
+        "post-install-cmd": [
+            "@binaries",
+            "@document-root"
+        ],
+        "post-update-cmd": [
+            "@binaries",
+            "@document-root"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "4.0.x-dev"


### PR DESCRIPTION
Note: The console will only be added if this project is the project root
(i.e., usually when developing the package), not if is a requirement of
the base-distribution package (or any other package).
