### PR TITLE
[CLEANUP] Clean up the .travis.yml formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,57 +1,74 @@
 language: php
+
 matrix:
   include:
   - php: 7.0
   - php: 7.1
+
 services:
 - mysql
+
 env:
   global:
   - PHPLIST_DATABASE_NAME=phplist
   - PHPLIST_DATABASE_USER=travis
   - PHPLIST_DATABASE_PASSWORD=''
+
 notifications:
   slack:
     rooms:
       secure: cwCoc5P28/IG7s+P9Hj5cw4jbVXHDuYcTQoj9CJNNzWb5/Mfu7472EzjRkFP9FL86LGa3JfnoTHBRxfvDS4I1soapPX8hHNZFL68iOgXtKxpWpYTeJszV09W2Cc2EzOWn/Th1Q6D5DfLPGmDTgaIiFS70FJ+3VOwNl0GFjtryAJxRdzGTRkbKDZUd/jA6JXOEu3+Rk9rZeHl90bI7CWDJS5sz5Ubzy7mmEFyn4+S1ktFkKeCOdD+CS3r4DCv1TufAg6fRMflBU5chw8sypqtEE6FqlH1bYZ3OMLaQ4MZZH+4yL+EfnUx4zmXN0L7tOSGKNeoCwiTk5AnlJzUaop0+d3FQXNEvsXvq1UuIEe8lm8bkn1gMvMBvo0rh2YpWLErHBFXclS03uSUYU0EQPz/kAuNfDD7a+v62vgSTi8t/7Pqr099J/V6b7cAtlqf1x38/U5QKVOZ4g2zUV3nVbPpoaR8pC/PJ0Jvz4g6vIaWiSqtCWkUV2CDHblSNt+ySIfadwgFBBbylPOXNBorzkRn+QUFbeq2iOMM0FLnhKc+XPIyK1ewmCfm5bj1kUOfoN09zSwauigNI3Ag6MWPAZNY0qpDyCqGOm8KcFCX5X57eekNHjRNM3Zac3OSTjlQ9jV9MmDCHWxvrmKBGM9a5d5u6bS/8Mqxgm/FsNk4b1HgsN8=
   on_success: change
   on_failure: always
+
 sudo: false
+
 cache:
   directories:
   - vendor
   - "$HOME/.composer/cache"
+
 before_install:
 - phpenv config-rm xdebug.ini
+
 install:
 - composer install
+
 before_script:
-- 'echo; echo "Creating the database and importing the database schema"; mysql -e
-  "CREATE DATABASE ${PHPLIST_DATABASE_NAME};"; mysql -u root -e "GRANT ALL ON ${PHPLIST_DATABASE_NAME}.*
-  TO ${PHPLIST_DATABASE_USER}@''%'';"; mysql ${PHPLIST_DATABASE_NAME} < vendor/phplist/phplist4-core/Database/Schema.sql;
+- >
+  echo;
+  echo "Creating the database and importing the database schema";
+  mysql -e "CREATE DATABASE ${PHPLIST_DATABASE_NAME};";
+  mysql -u root -e "GRANT ALL ON ${PHPLIST_DATABASE_NAME}.* TO ${PHPLIST_DATABASE_USER}@''%'';";
+  mysql ${PHPLIST_DATABASE_NAME} < vendor/phplist/phplist4-core/Database/Schema.sql;
 
-'
 script:
-- 'echo; echo "Linting all PHP files"; find Classes/ Tests/ -name ''*.php'' -print0
-  | xargs -0 -n 1 -P 4 php -l;
+- >
+  echo;
+  echo "Linting all PHP files";
+  find Classes/ Tests/ -name ''*.php'' -print0 | xargs -0 -n 1 -P 4 php -l;
 
-'
-- 'echo; echo "Running the unit tests"; vendor/bin/phpunit -c Configuration/PHPUnit/phpunit.xml
-  Tests/Unit/;
+- >
+  echo;
+  echo "Running the unit tests";
+  vendor/bin/phpunit -c Configuration/PHPUnit/phpunit.xml Tests/Unit/;
 
-'
-- 'echo; echo "Running the integration tests"; vendor/bin/phpunit -c Configuration/PHPUnit/phpunit.xml
-  Tests/Integration/;
+- >
+  echo;
+  echo "Running the integration tests";
+  vendor/bin/phpunit -c Configuration/PHPUnit/phpunit.xml Tests/Integration/;
 
-'
-- 'echo; echo "Running the static analysis"; vendor/bin/phpstan analyse -l 5 Classes/
-  Tests/;
+- >
+  echo;
+  echo "Running the static analysis";
+  vendor/bin/phpstan analyse -l 5 Classes/ Tests/;
 
-'
-- 'echo; echo "Running PHPMD"; vendor/bin/phpmd Classes/ text vendor/phplist/phplist4-core/Configuration/PHPMD/rules.xml;
+- >
+  echo;
+  echo "Running PHPMD";
+  vendor/bin/phpmd Classes/ text vendor/phplist/phplist4-core/Configuration/PHPMD/rules.xml;
 
-'
-- 'echo; echo "Running PHP_CodeSniffer"; vendor/bin/phpcs --standard=vendor/phplist/phplist4-core/Configuration/PhpCodeSniffer/
-  Classes/ Tests/;
-
-'
+- >
+  echo;
+  echo "Running PHP_CodeSniffer";
+  vendor/bin/phpcs --standard=vendor/phplist/phplist4-core/Configuration/PhpCodeSniffer/ Classes/ Tests/;


### PR DESCRIPTION
- add blank lines
- use a more readable syntax for multi-line scripts

This undoes some of the reformatting done by the Travis CLI script.