### PR TITLE
[BUGFIX] Fix the symfony-app-dir setting in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "branch-alias": {
             "dev-master": "4.0.x-dev"
         },
-        "symfony-app-dir": "",
+        "symfony-app-dir": "bin",
         "symfony-bin-dir": "bin",
         "symfony-var-dir": "var",
         "symfony-web-dir": "web",


### PR DESCRIPTION
For the automatic cache creation to also work on Mac OS (in addition
to Linux), the setting needs to be changed.