### PR TITLE
[BUGFIX] Keep text/html as content-type for non-REST routes

### DIFF
--- a/Tests/Integration/Controller/SessionControllerTest.php
+++ b/Tests/Integration/Controller/SessionControllerTest.php
@@ -54,6 +54,18 @@ class SessionControllerTest extends AbstractControllerTest
     /**
      * @test
      */
+    public function rootUrlHasHtmlContentType()
+    {
+        $this->client->request('get', '/');
+
+        $response = $this->client->getResponse();
+
+        self::assertContains('text/html', (string)$response->headers);
+    }
+
+    /**
+     * @test
+     */
     public function getSessionsIsNotAllowed()
     {
         $this->client->request('get', '/api/v2/sessions');

--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,12 @@
                         "enabled": true,
                         "rules": [
                             {
+                                "path": "^/api/v2/",
                                 "fallback_format": "json"
+                            },
+                            {
+                                "path": "^/",
+                                "fallback_format": "html"
                             }
                         ]
                     },


### PR DESCRIPTION
The application/json content type should only be used for routes
that are part of our REST API.