### PR TITLE
[BUGFIX] Use "UTC" as time zone in the integration tests

### DIFF
--- a/Tests/Integration/Controller/AbstractControllerTest.php
+++ b/Tests/Integration/Controller/AbstractControllerTest.php
@@ -67,6 +67,10 @@ abstract class AbstractControllerTest extends WebTestCase
 
     protected function setUp()
     {
+        // This makes sure that all DateTime instances use the same time zone, thus making the dates in the
+        // JSON provided by the REST API easier to test.
+        date_default_timezone_set('UTC');
+
         $this->initializeDatabaseTester();
         $this->bootstrap = Bootstrap::getInstance()->setEnvironment(Environment::TESTING)->configure();
         $this->entityManager = $this->bootstrap->getEntityManager();


### PR DESCRIPTION
This makes the JSON representation of dates independent of the test
machine's PHP time zone.