### PR TITLE
[TASK] Use snake_case for the JSON request parameter keys

### DIFF
--- a/Classes/Controller/SessionController.php
+++ b/Classes/Controller/SessionController.php
@@ -57,7 +57,7 @@ class SessionController extends FOSRestController implements ClassResourceInterf
     {
         $this->validateCreateRequest($request);
         $administrator = $this->administratorRepository->findOneByLoginCredentials(
-            $request->get('loginName'),
+            $request->get('login_name'),
             $request->get('password')
         );
         if ($administrator === null) {
@@ -83,7 +83,7 @@ class SessionController extends FOSRestController implements ClassResourceInterf
         if ($request->getContent() === '') {
             throw new BadRequestHttpException('Empty JSON data', null, 1500559729794);
         }
-        if (empty($request->get('loginName')) || empty($request->get('password'))) {
+        if (empty($request->get('login_name')) || empty($request->get('password'))) {
             throw new BadRequestHttpException('Incomplete credentials', null, 1500562647846);
         }
     }

--- a/Documentation/Api/RestApi.apib
+++ b/Documentation/Api/RestApi.apib
@@ -17,7 +17,7 @@ Given valid login data, this will generate a login token that will be
 valid for 1 hour. It takes a JSON object containing the following key-value
 pairs:
 
-+ `loginName` (string): the login name of the superuser administrator to log in
++ `login_name` (string): the login name of the superuser administrator to log in
 + `password` (string): the plain text password
 
 Non-superuser administrators cannot authenticate via the REST API.
@@ -28,7 +28,7 @@ that require authentication. (The basic auth user name can be any string.)
 + Request (application/json)
 
     {
-        "loginName": "admin",
+        "login_name": "admin",
         "password": "eetIc/Gropvoc1"
     }
 

--- a/Tests/Integration/Controller/SessionControllerTest.php
+++ b/Tests/Integration/Controller/SessionControllerTest.php
@@ -101,9 +101,9 @@ class SessionControllerTest extends AbstractControllerTest
     public function incompleteCredentialsDataProvider(): array
     {
         return [
-            'neither loginName nor password' => ['{}'],
-            'loginName, but no password' => ['{"loginName": "larry@example.com"}'],
-            'password, but no loginName' => ['{"password": "t67809oibuzfq2qg3"}'],
+            'neither login_name nor password' => ['{}'],
+            'login_name, but no password' => ['{"login_name": "larry@example.com"}'],
+            'password, but no login_name' => ['{"password": "t67809oibuzfq2qg3"}'],
         ];
     }
 
@@ -135,7 +135,7 @@ class SessionControllerTest extends AbstractControllerTest
 
         $loginName = 'john.doe';
         $password = 'a sandwich and a cup of coffee';
-        $jsonData = ['loginName' => $loginName, 'password' => $password];
+        $jsonData = ['login_name' => $loginName, 'password' => $password];
 
         $this->jsonRequest('post', '/api/v2/sessions', [], [], [], json_encode($jsonData));
 
@@ -158,7 +158,7 @@ class SessionControllerTest extends AbstractControllerTest
 
         $loginName = 'john.doe';
         $password = 'Bazinga!';
-        $jsonData = ['loginName' => $loginName, 'password' => $password];
+        $jsonData = ['login_name' => $loginName, 'password' => $password];
 
         $this->jsonRequest('post', '/api/v2/sessions', [], [], [], json_encode($jsonData));
 
@@ -176,7 +176,7 @@ class SessionControllerTest extends AbstractControllerTest
 
         $loginName = 'john.doe';
         $password = 'Bazinga!';
-        $jsonData = ['loginName' => $loginName, 'password' => $password];
+        $jsonData = ['login_name' => $loginName, 'password' => $password];
 
         $this->jsonRequest('post', '/api/v2/sessions', [], [], [], json_encode($jsonData));
 


### PR DESCRIPTION
This makes the request naming schema consistent with the response naming
schema.