### PR TITLE
[BUGFIX] Install dependencies before importing the DB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,17 @@ cache:
 
 before_install:
 - phpenv config-rm xdebug.ini
+
+install:
+- composer install
+
+before_script:
 - >
   echo;
   echo "Creating the database and importing the database schema";
   mysql -e "CREATE DATABASE ${PHPLIST_DATABASE_NAME};";
   mysql -u root -e "GRANT ALL ON ${PHPLIST_DATABASE_NAME}.* TO '${PHPLIST_DATABASE_USER}'@'%';";
   mysql ${PHPLIST_DATABASE_NAME} < vendor/phplist/phplist4-core/Database/Schema.sql;
-
-install:
-- composer install
 
 script:
 - >


### PR DESCRIPTION
The dependencies provide the SQL file that will be used for the DB import.
So this order is necessary for the build to pass reliably.