### PR TITLE
[TASK] Use static:: instead of self::

### DIFF
--- a/Tests/Integration/Composer/ScriptsTest.php
+++ b/Tests/Integration/Composer/ScriptsTest.php
@@ -17,7 +17,7 @@ class ScriptsTest extends TestCase
      */
     public function webDirectoryHasBeenCreated()
     {
-        self::assertDirectoryExists($this->getAbsoluteWebDirectoryPath());
+        static::assertDirectoryExists($this->getAbsoluteWebDirectoryPath());
     }
 
     /**
@@ -48,7 +48,7 @@ class ScriptsTest extends TestCase
      */
     public function webDirectoryFilesExist(string $fileName)
     {
-        self::assertFileExists($this->getAbsoluteWebDirectoryPath() . $fileName);
+        static::assertFileExists($this->getAbsoluteWebDirectoryPath() . $fileName);
     }
 
     /**
@@ -56,7 +56,7 @@ class ScriptsTest extends TestCase
      */
     public function binariesDirectoryHasBeenCreated()
     {
-        self::assertDirectoryExists($this->getAbsoluteBinariesDirectoryPath());
+        static::assertDirectoryExists($this->getAbsoluteBinariesDirectoryPath());
     }
 
     /**
@@ -84,7 +84,7 @@ class ScriptsTest extends TestCase
      */
     public function binariesExist(string $fileName)
     {
-        self::assertFileExists($this->getAbsoluteBinariesDirectoryPath() . $fileName);
+        static::assertFileExists($this->getAbsoluteBinariesDirectoryPath() . $fileName);
     }
 
     /**
@@ -100,7 +100,7 @@ class ScriptsTest extends TestCase
      */
     public function bundleConfigurationFileExists()
     {
-        self::assertFileExists($this->getBundleConfigurationFilePath());
+        static::assertFileExists($this->getBundleConfigurationFilePath());
     }
 
     /**
@@ -123,7 +123,7 @@ class ScriptsTest extends TestCase
     {
         $fileContents = file_get_contents($this->getBundleConfigurationFilePath());
 
-        self::assertContains($bundleClassName, $fileContents);
+        static::assertContains($bundleClassName, $fileContents);
     }
 
     /**
@@ -139,7 +139,7 @@ class ScriptsTest extends TestCase
      */
     public function moduleRoutesConfigurationFileExists()
     {
-        self::assertFileExists($this->getModuleRoutesConfigurationFilePath());
+        static::assertFileExists($this->getModuleRoutesConfigurationFilePath());
     }
 
     /**
@@ -163,7 +163,7 @@ class ScriptsTest extends TestCase
     {
         $fileContents = file_get_contents($this->getModuleRoutesConfigurationFilePath());
 
-        self::assertContains($routeSearchString, $fileContents);
+        static::assertContains($routeSearchString, $fileContents);
     }
 
     /**
@@ -171,7 +171,7 @@ class ScriptsTest extends TestCase
      */
     public function parametersConfigurationFileExists()
     {
-        self::assertFileExists(dirname(__DIR__, 3) . '/Configuration/parameters.yml');
+        static::assertFileExists(dirname(__DIR__, 3) . '/Configuration/parameters.yml');
     }
 
     /**
@@ -179,6 +179,6 @@ class ScriptsTest extends TestCase
      */
     public function modulesConfigurationFileExists()
     {
-        self::assertFileExists(dirname(__DIR__, 3) . '/Configuration/config_modules.yml');
+        static::assertFileExists(dirname(__DIR__, 3) . '/Configuration/config_modules.yml');
     }
 }

--- a/Tests/Integration/Controller/AbstractControllerTest.php
+++ b/Tests/Integration/Controller/AbstractControllerTest.php
@@ -76,9 +76,9 @@ abstract class AbstractControllerTest extends WebTestCase
         $this->initializeDatabaseTester();
         $this->bootstrap = Bootstrap::getInstance()->setEnvironment(Environment::TESTING)->configure();
         $this->entityManager = $this->bootstrap->getEntityManager();
-        self::assertTrue($this->entityManager->isOpen());
+        static::assertTrue($this->entityManager->isOpen());
 
-        $this->client = self::createClient(['environment' => Environment::TESTING]);
+        $this->client = static::createClient(['environment' => Environment::TESTING]);
     }
 
     /**
@@ -226,8 +226,8 @@ abstract class AbstractControllerTest extends WebTestCase
         array $server = [],
         string $content = null
     ): Crawler {
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
-        $this->getDataSet()->addTable(self::TOKEN_TABLE_NAME, __DIR__ . '/Fixtures/AdministratorToken.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TOKEN_TABLE_NAME, __DIR__ . '/Fixtures/AdministratorToken.csv');
         $this->applyDatabaseChanges();
 
         $serverWithAuthentication = $server;
@@ -256,7 +256,7 @@ abstract class AbstractControllerTest extends WebTestCase
      */
     protected function assertJsonResponseContentEquals(array $expected)
     {
-        self::assertSame($expected, $this->getDecodedJsonResponseContent());
+        static::assertSame($expected, $this->getDecodedJsonResponseContent());
     }
 
     /**
@@ -270,8 +270,8 @@ abstract class AbstractControllerTest extends WebTestCase
     {
         $response = $this->client->getResponse();
 
-        self::assertSame($status, $response->getStatusCode());
-        self::assertContains('application/json', (string)$response->headers);
+        static::assertSame($status, $response->getStatusCode());
+        static::assertContains('application/json', (string)$response->headers);
     }
 
     /**
@@ -334,7 +334,7 @@ abstract class AbstractControllerTest extends WebTestCase
     {
         $this->assertHttpStatusWithJsonContentType(Response::HTTP_FORBIDDEN);
 
-        self::assertSame(
+        static::assertSame(
             [
                 'code' => Response::HTTP_FORBIDDEN,
                 'message' => 'No valid session key was provided as basic auth password.',
@@ -352,7 +352,7 @@ abstract class AbstractControllerTest extends WebTestCase
     {
         $response = $this->client->getResponse();
 
-        self::assertSame(Response::HTTP_METHOD_NOT_ALLOWED, $response->getStatusCode());
+        static::assertSame(Response::HTTP_METHOD_NOT_ALLOWED, $response->getStatusCode());
     }
 
     /**
@@ -365,7 +365,7 @@ abstract class AbstractControllerTest extends WebTestCase
     {
         $this->assertHttpStatusWithJsonContentType(Response::HTTP_CONFLICT);
 
-        self::assertSame(
+        static::assertSame(
             [
                 'code' => Response::HTTP_CONFLICT,
                 'message' => 'This resource already exists.',

--- a/Tests/Integration/Controller/ListControllerTest.php
+++ b/Tests/Integration/Controller/ListControllerTest.php
@@ -32,7 +32,7 @@ class ListControllerTest extends AbstractControllerTest
      */
     public function controllerIsAvailableViaContainer()
     {
-        self::assertInstanceOf(ListController::class, $this->client->getContainer()->get(ListController::class));
+        static::assertInstanceOf(ListController::class, $this->client->getContainer()->get(ListController::class));
     }
 
     /**
@@ -50,8 +50,8 @@ class ListControllerTest extends AbstractControllerTest
      */
     public function getListsWithExpiredSessionKeyReturnsForbiddenStatus()
     {
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
-        $this->getDataSet()->addTable(self::TOKEN_TABLE_NAME, __DIR__ . '/Fixtures/AdministratorToken.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TOKEN_TABLE_NAME, __DIR__ . '/Fixtures/AdministratorToken.csv');
         $this->applyDatabaseChanges();
 
         $this->client->request(
@@ -80,7 +80,7 @@ class ListControllerTest extends AbstractControllerTest
      */
     public function getListsWithCurrentSessionKeyReturnsListData()
     {
-        $this->getDataSet()->addTable(self::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $this->authenticatedJsonRequest('get', '/api/v2/lists');
@@ -116,7 +116,7 @@ class ListControllerTest extends AbstractControllerTest
      */
     public function getListMembersForExistingListWithoutSessionKeyReturnsForbiddenStatus()
     {
-        $this->getDataSet()->addTable(self::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $this->client->request('get', '/api/v2/lists/1/members');
@@ -129,9 +129,9 @@ class ListControllerTest extends AbstractControllerTest
      */
     public function getListMembersForExistingListWithExpiredSessionKeyReturnsForbiddenStatus()
     {
-        $this->getDataSet()->addTable(self::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
-        $this->getDataSet()->addTable(self::TOKEN_TABLE_NAME, __DIR__ . '/Fixtures/AdministratorToken.csv');
+        $this->getDataSet()->addTable(static::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::TOKEN_TABLE_NAME, __DIR__ . '/Fixtures/AdministratorToken.csv');
         $this->applyDatabaseChanges();
 
         $this->client->request(
@@ -160,7 +160,7 @@ class ListControllerTest extends AbstractControllerTest
      */
     public function getListMembersWithCurrentSessionKeyForExistingListReturnsOkayStatus()
     {
-        $this->getDataSet()->addTable(self::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $this->authenticatedJsonRequest('get', '/api/v2/lists/1/members');
@@ -173,7 +173,7 @@ class ListControllerTest extends AbstractControllerTest
      */
     public function getListMembersWithCurrentSessionKeyForExistingListWithoutSubscribersReturnsEmptyArray()
     {
-        $this->getDataSet()->addTable(self::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
         $this->applyDatabaseChanges();
 
         $this->authenticatedJsonRequest('get', '/api/v2/lists/1/members');
@@ -186,9 +186,9 @@ class ListControllerTest extends AbstractControllerTest
      */
     public function getListMembersWithCurrentSessionKeyForExistingListWithSubscribersReturnsSubscribers()
     {
-        $this->getDataSet()->addTable(self::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIBER_TABLE_NAME, __DIR__ . '/Fixtures/Subscriber.csv');
-        $this->getDataSet()->addTable(self::SUBSCRIPTION_TABLE_NAME, __DIR__ . '/Fixtures/Subscription.csv');
+        $this->getDataSet()->addTable(static::LISTS_TABLE_NAME, __DIR__ . '/Fixtures/SubscriberList.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIPTION_TABLE_NAME, __DIR__ . '/Fixtures/Subscription.csv');
         $this->applyDatabaseChanges();
 
         $this->authenticatedJsonRequest('get', '/api/v2/lists/2/members');

--- a/Tests/Integration/Controller/SessionControllerTest.php
+++ b/Tests/Integration/Controller/SessionControllerTest.php
@@ -34,7 +34,10 @@ class SessionControllerTest extends AbstractControllerTest
      */
     public function controllerIsAvailableViaContainer()
     {
-        self::assertInstanceOf(SessionController::class, $this->client->getContainer()->get(SessionController::class));
+        static::assertInstanceOf(
+            SessionController::class,
+            $this->client->getContainer()->get(SessionController::class)
+        );
     }
 
     /**
@@ -130,7 +133,7 @@ class SessionControllerTest extends AbstractControllerTest
      */
     public function postSessionsWithInvalidCredentialsReturnsNotAuthorized()
     {
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
         $this->applyDatabaseChanges();
 
         $loginName = 'john.doe';
@@ -153,7 +156,7 @@ class SessionControllerTest extends AbstractControllerTest
      */
     public function postSessionsActionWithValidCredentialsReturnsCreatedHttpStatus()
     {
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
         $this->applyDatabaseChanges();
 
         $loginName = 'john.doe';
@@ -171,7 +174,7 @@ class SessionControllerTest extends AbstractControllerTest
     public function postSessionsActionWithValidCredentialsCreatesToken()
     {
         $administratorId = 1;
-        $this->getDataSet()->addTable(self::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
+        $this->getDataSet()->addTable(static::ADMINISTRATOR_TABLE_NAME, __DIR__ . '/Fixtures/Administrator.csv');
         $this->applyDatabaseChanges();
 
         $loginName = 'john.doe';
@@ -187,9 +190,9 @@ class SessionControllerTest extends AbstractControllerTest
 
         /** @var AdministratorToken $token */
         $token = $this->administratorTokenRepository->find($tokenId);
-        self::assertNotNull($token);
-        self::assertSame($key, $token->getKey());
-        self::assertSame($expiry, $token->getExpiry()->format(\DateTime::ATOM));
-        self::assertSame($administratorId, $token->getAdministrator()->getId());
+        static::assertNotNull($token);
+        static::assertSame($key, $token->getKey());
+        static::assertSame($expiry, $token->getExpiry()->format(\DateTime::ATOM));
+        static::assertSame($administratorId, $token->getAdministrator()->getId());
     }
 }

--- a/Tests/Integration/Controller/SubscriberControllerTest.php
+++ b/Tests/Integration/Controller/SubscriberControllerTest.php
@@ -37,7 +37,7 @@ class SubscriberControllerTest extends AbstractControllerTest
      */
     public function controllerIsAvailableViaContainer()
     {
-        self::assertInstanceOf(
+        static::assertInstanceOf(
             SubscriberController::class,
             $this->client->getContainer()->get(SubscriberController::class)
         );
@@ -68,7 +68,7 @@ class SubscriberControllerTest extends AbstractControllerTest
      */
     public function postSubscribersWithValidSessionKeyAndMinimalValidSubscriberDataCreatesResource()
     {
-        $this->touchDatabaseTable(self::SUBSCRIBER_TABLE_NAME);
+        $this->touchDatabaseTable(static::SUBSCRIBER_TABLE_NAME);
 
         $email = 'subscriber@example.com';
         $jsonData = ['email' => $email];
@@ -83,7 +83,7 @@ class SubscriberControllerTest extends AbstractControllerTest
      */
     public function postSubscribersWithValidSessionKeyAndMinimalValidDataReturnsIdAndUniqueId()
     {
-        $this->touchDatabaseTable(self::SUBSCRIBER_TABLE_NAME);
+        $this->touchDatabaseTable(static::SUBSCRIBER_TABLE_NAME);
 
         $email = 'subscriber@example.com';
         $jsonData = ['email' => $email];
@@ -92,8 +92,8 @@ class SubscriberControllerTest extends AbstractControllerTest
 
         $responseContent = $this->getDecodedJsonResponseContent();
 
-        self::assertGreaterThan(0, $responseContent['id']);
-        self::assertRegExp('/^[0-9a-f]{32}$/', $responseContent['unique_id']);
+        static::assertGreaterThan(0, $responseContent['id']);
+        static::assertRegExp('/^[0-9a-f]{32}$/', $responseContent['unique_id']);
     }
 
     /**
@@ -101,7 +101,7 @@ class SubscriberControllerTest extends AbstractControllerTest
      */
     public function postSubscribersWithValidSessionKeyAndValidDataCreatesSubscriber()
     {
-        $this->touchDatabaseTable(self::SUBSCRIBER_TABLE_NAME);
+        $this->touchDatabaseTable(static::SUBSCRIBER_TABLE_NAME);
 
         $email = 'subscriber@example.com';
         $jsonData = ['email' => $email];
@@ -111,7 +111,7 @@ class SubscriberControllerTest extends AbstractControllerTest
         $responseContent = $this->getDecodedJsonResponseContent();
 
         $subscriberId = $responseContent['id'];
-        self::assertInstanceOf(Subscriber::class, $this->subscriberRepository->find($subscriberId));
+        static::assertInstanceOf(Subscriber::class, $this->subscriberRepository->find($subscriberId));
     }
 
     /**
@@ -119,7 +119,7 @@ class SubscriberControllerTest extends AbstractControllerTest
      */
     public function postSubscribersWithValidSessionKeyAndExistingEmailAddressCreatesConflictStatus()
     {
-        $this->getDataSet()->addTable(self::SUBSCRIBER_TABLE_NAME, __DIR__ . '/Fixtures/Subscriber.csv');
+        $this->getDataSet()->addTable(static::SUBSCRIBER_TABLE_NAME, __DIR__ . '/Fixtures/Subscriber.csv');
         $this->applyDatabaseChanges();
 
         $email = 'oliver@example.com';
@@ -159,7 +159,7 @@ class SubscriberControllerTest extends AbstractControllerTest
      */
     public function postSubscribersWithInvalidDataCreatesUnprocessableEntityStatus(array $jsonData)
     {
-        $this->touchDatabaseTable(self::SUBSCRIBER_TABLE_NAME);
+        $this->touchDatabaseTable(static::SUBSCRIBER_TABLE_NAME);
 
         $this->authenticatedJsonRequest('post', '/api/v2/subscribers', [], [], [], json_encode($jsonData));
 
@@ -171,7 +171,7 @@ class SubscriberControllerTest extends AbstractControllerTest
      */
     public function postSubscribersWithValidSessionKeyAssignsProvidedSubscriberData()
     {
-        $this->touchDatabaseTable(self::SUBSCRIBER_TABLE_NAME);
+        $this->touchDatabaseTable(static::SUBSCRIBER_TABLE_NAME);
 
         $email = 'subscriber@example.com';
         $jsonData = [
@@ -186,10 +186,10 @@ class SubscriberControllerTest extends AbstractControllerTest
 
         $responseContent = $this->getDecodedJsonResponseContent();
 
-        self::assertSame($email, $responseContent['email']);
-        self::assertTrue($responseContent['confirmed']);
-        self::assertTrue($responseContent['blacklisted']);
-        self::assertTrue($responseContent['html_email']);
-        self::assertTrue($responseContent['disabled']);
+        static::assertSame($email, $responseContent['email']);
+        static::assertTrue($responseContent['confirmed']);
+        static::assertTrue($responseContent['blacklisted']);
+        static::assertTrue($responseContent['html_email']);
+        static::assertTrue($responseContent['disabled']);
     }
 }

--- a/Tests/Integration/Routing/RoutingTest.php
+++ b/Tests/Integration/Routing/RoutingTest.php
@@ -24,7 +24,7 @@ class RoutingTest extends WebTestCase
     {
         Bootstrap::getInstance()->setEnvironment(Environment::TESTING)->configure();
 
-        $this->client = self::createClient(['environment' => Environment::TESTING]);
+        $this->client = static::createClient(['environment' => Environment::TESTING]);
     }
 
     protected function tearDown()
@@ -41,6 +41,6 @@ class RoutingTest extends WebTestCase
 
         $response = $this->client->getResponse();
 
-        self::assertContains('text/html', (string)$response->headers);
+        static::assertContains('text/html', (string)$response->headers);
     }
 }

--- a/Tests/System/Controller/SessionControllerTest.php
+++ b/Tests/System/Controller/SessionControllerTest.php
@@ -60,8 +60,8 @@ class SessionControllerTest extends TestCase
             '/api/v2/sessions',
             ['base_uri' => $this->getBaseUrl(), 'body' => \json_encode($jsonData)]
         );
-        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
-        self::assertSame(
+        static::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        static::assertSame(
             [
                 'code' => Response::HTTP_UNAUTHORIZED,
                 'message' => 'Not authorized',

--- a/Tests/Unit/PhpListRestBundleTest.php
+++ b/Tests/Unit/PhpListRestBundleTest.php
@@ -29,6 +29,6 @@ class PhpListRestBundleTest extends TestCase
      */
     public function classIsBundle()
     {
-        self::assertInstanceOf(Bundle::class, $this->subject);
+        static::assertInstanceOf(Bundle::class, $this->subject);
     }
 }


### PR DESCRIPTION
This will allow for subclasses to overwrite methods and constants and hence
is the current recommended practice.