### PR TITLE
[BUGFIX] Fix Composer-related build failure with PHP 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "roave/security-advisories": "dev-master"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5.0",
+        "phpunit/phpunit": "^6.5.6",
+        "phpunit/phpunit-mock-objects": "^5.0.6",
         "phpunit/dbunit": "^3.0.0",
         "guzzlehttp/guzzle": "^6.3.0",
         "squizlabs/php_codesniffer": "^3.2.0",


### PR DESCRIPTION
Composer tries to install doctrine/instantiator 1.1.0 on PHP 7.0,
but this version requires PHP ^7.1. This seems to be a bug in Composer,
and requiring the latest PHP-7.0-compatible version of
phpunit/phpunit-mock-objects works around this issue.