### PR TITLE
[BUGFIX] Pin sensio/framework-extra-bundle at 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 
 ### Fixed
+- Prevent crashes from sensio/framework-extra-bundle updates (#105)
 - Make the exception codes 32-bit safe (#100)
 - Always truncate the DB tables after an integration test (#86)
 

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
 
         "phplist/core": "4.0.x-dev",
         "friendsofsymfony/rest-bundle": "^2.3",
+        "sensio/framework-extra-bundle": "5.1.0",
 
         "roave/security-advisories": "dev-master"
     },


### PR DESCRIPTION
sensio/framework-extra-bundle 5.1.1 has renamed some services.
friendsofsymfony/rest-bundle has not yet caught up with the new service
IDs, causing all REST routes to break. To work around this until
friendsofsymfony/rest-bundle has fixed this, sensio/framework-extra-bundle
is pinned to version 5.1.0.

This is the corresponding bug report:
https://github.com/FriendsOfSymfony/FOSRestBundle/issues/1878