### PR TITLE
Whitelist BadRequestHttpException so that messages are not sanitized

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,9 +121,14 @@
                         "view_response_listener": {
                             "enabled": true
                         }
+
                     },
                     "exception": {
-                        "enabled": true
+                        "enabled": true,
+                        "messages": {
+                            "Symfony\\Component\\HttpKernel\\Exception\\BadRequestHttpException": true
+                        }
+
                     }
                 }
             }


### PR DESCRIPTION
Signed-off-by: Xheni Myrtaj <myrtajxheni@gmail.com>

### Summary
fosRest bundle filters the messages as they may contain sensitive content but in our case, we want to display messages such as: incomplete credentials.


Fix #109 