### PR TITLE
Add security headers to the default response 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,6 +128,9 @@
                         "messages": {
                             "Symfony\\Component\\HttpKernel\\Exception\\BadRequestHttpException": true
                         }
+                    },
+                    "service": {
+                        "view_handler": "my.secure_view_handler"
 
                     }
                 }

--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,6 @@
                     },
                     "service": {
                         "view_handler": "my.secure_view_handler"
-
                     }
                 }
             }

--- a/config/services.yml
+++ b/config/services.yml
@@ -11,4 +11,4 @@ services:
     my.secure_view_handler:
       parent: fos_rest.view_handler.default
       calls:
-       - ['registerHandler', [ 'json', ['@my.secure_handler', 'createResponse'] ] ]
+        - ['registerHandler', [ 'json', ['@my.secure_handler', 'createResponse'] ] ]

--- a/config/services.yml
+++ b/config/services.yml
@@ -4,3 +4,11 @@ services:
         public: true
         autowire: true
         tags: ['controller.service_arguments']
+
+    my.secure_handler:
+      class: \PhpList\RestBundle\ViewHandler\SecuredViewHandler
+
+    my.secure_view_handler:
+      parent: fos_rest.view_handler.default
+      calls:
+       - ['registerHandler', [ 'json', ["@my.secure_handler", 'createResponse'] ] ]

--- a/config/services.yml
+++ b/config/services.yml
@@ -11,4 +11,4 @@ services:
     my.secure_view_handler:
       parent: fos_rest.view_handler.default
       calls:
-       - ['registerHandler', [ 'json', ["@my.secure_handler", 'createResponse'] ] ]
+       - ['registerHandler', [ 'json', ['@my.secure_handler', 'createResponse'] ] ]

--- a/src/ViewHandler/SecuredViewHandler.php
+++ b/src/ViewHandler/SecuredViewHandler.php
@@ -23,7 +23,7 @@ class SecuredViewHandler
      *
      * @return Response
      */
-    public function createResponse(ViewHandler $handler, View $view, Request $request, string $format):Response
+    public function createResponse(ViewHandler $handler, View $view, Request $request, string $format): Response
     {
         $view->setHeaders(
             [

--- a/src/ViewHandler/SecuredViewHandler.php
+++ b/src/ViewHandler/SecuredViewHandler.php
@@ -23,7 +23,7 @@ class SecuredViewHandler
      *
      * @return Response
      */
-    public function createResponse(ViewHandler $handler, View $view, Request $request, string $format)
+    public function createResponse(ViewHandler $handler, View $view, Request $request, string $format):Response
     {
         $view->setHeaders(
             [

--- a/src/ViewHandler/SecuredViewHandler.php
+++ b/src/ViewHandler/SecuredViewHandler.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace PhpList\RestBundle\ViewHandler;
+
+use FOS\RestBundle\View\View;
+use FOS\RestBundle\View\ViewHandler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * This class is used to add headers to the default response.
+ * @author Xheni Myrtaj <xheni@phplist.com> .
+ */
+class SecuredViewHandler
+{
+
+    /**
+     * @param ViewHandler $viewHandler
+     * @param View        $view
+     * @param Request     $request
+     * @param string      $format
+     *
+     * @return Response
+     */
+    public function createResponse(ViewHandler $handler, View $view, Request $request, $format)
+    {
+        $view->setHeaders([
+            'X-Content-Type-Options' => 'nosniff',
+            'Content-Security-Policy' => "default-src 'none'",
+            'X-Frame-Options' => 'DENY'
+        ]);
+
+        return $handler->createResponse($view, $request, $format);
+    }
+}

--- a/src/ViewHandler/SecuredViewHandler.php
+++ b/src/ViewHandler/SecuredViewHandler.php
@@ -15,7 +15,6 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class SecuredViewHandler
 {
-
     /**
      * @param ViewHandler $viewHandler
      * @param View $view

--- a/src/ViewHandler/SecuredViewHandler.php
+++ b/src/ViewHandler/SecuredViewHandler.php
@@ -10,26 +10,29 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * This class is used to add headers to the default response.
- * @author Xheni Myrtaj <xheni@phplist.com> .
+ *
+ * @author Xheni Myrtaj <xheni@phplist.com>
  */
 class SecuredViewHandler
 {
 
     /**
      * @param ViewHandler $viewHandler
-     * @param View        $view
-     * @param Request     $request
-     * @param string      $format
+     * @param View $view
+     * @param Request $request
+     * @param string $format
      *
      * @return Response
      */
     public function createResponse(ViewHandler $handler, View $view, Request $request, string $format)
     {
-        $view->setHeaders([
-            'X-Content-Type-Options' => 'nosniff',
-            'Content-Security-Policy' => "default-src 'none'",
-            'X-Frame-Options' => 'DENY'
-        ]);
+        $view->setHeaders(
+            [
+                'X-Content-Type-Options' => 'nosniff',
+                'Content-Security-Policy' => "default-src 'none'",
+                'X-Frame-Options' => 'DENY',
+            ]
+        );
 
         return $handler->createResponse($view, $request, $format);
     }

--- a/src/ViewHandler/SecuredViewHandler.php
+++ b/src/ViewHandler/SecuredViewHandler.php
@@ -23,7 +23,7 @@ class SecuredViewHandler
      *
      * @return Response
      */
-    public function createResponse(ViewHandler $handler, View $view, Request $request, $format)
+    public function createResponse(ViewHandler $handler, View $view, Request $request, string $format)
     {
         $view->setHeaders([
             'X-Content-Type-Options' => 'nosniff',

--- a/tests/System/Controller/SecuredViewHandlerTest.php
+++ b/tests/System/Controller/SecuredViewHandlerTest.php
@@ -59,7 +59,7 @@ class SecuredViewHandlerTest extends TestCase
         $expectedHeaders = [
             'X-Content-Type-Options' => 'nosniff',
             'Content-Security-Policy' => "default-src 'none'",
-            'X-Frame-Options' => 'DENY'
+            'X-Frame-Options' => 'DENY',
         ];
 
         foreach ($expectedHeaders as $key => $value) {

--- a/tests/System/Controller/SecuredViewHandlerTest.php
+++ b/tests/System/Controller/SecuredViewHandlerTest.php
@@ -1,5 +1,6 @@
 <?php
 declare(strict_types=1);
+
 namespace PhpList\RestBundle\Tests\System\Controller;
 
 use GuzzleHttp\Client;
@@ -9,13 +10,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Test for security headers
+ *
  * @author Xheni Myrtaj <xheni@phplist.com>
- *
- *
  */
 class SecuredViewHandlerTest extends TestCase
 {
-
     use SymfonyServerTrait;
 
     /**

--- a/tests/System/Controller/SecuredViewHandlerTest.php
+++ b/tests/System/Controller/SecuredViewHandlerTest.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+namespace PhpList\RestBundle\Tests\System\Controller;
+
+use GuzzleHttp\Client;
+use PhpList\Core\TestingSupport\Traits\SymfonyServerTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test for security headers
+ * @author Xheni Myrtaj <xheni@phplist.com>
+ *
+ *
+ */
+class SecuredViewHandlerTest extends TestCase
+{
+
+    use SymfonyServerTrait;
+
+    /**
+     * @var Client
+     */
+    private $httpClient = null;
+
+    protected function setUp()
+    {
+        $this->httpClient = new Client(['http_errors' => false]);
+    }
+
+    protected function tearDown()
+    {
+        $this->stopSymfonyServer();
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function environmentDataProvider(): array
+    {
+        return [
+            'test' => ['test'],
+            'dev' => ['dev'],
+        ];
+    }
+
+    /**
+     * @test
+     * @param string $environment
+     * @dataProvider environmentDataProvider
+     */
+    public function testSecurityHeaders(string $environment)
+    {
+        $this->startSymfonyServer($environment);
+
+        $response = $this->httpClient->get(
+            '/api/v2/sessions'
+        );
+        $expectedHeaders = [
+            'X-Content-Type-Options' => 'nosniff',
+            'Content-Security-Policy' => "default-src 'none'",
+            'X-Frame-Options' => 'DENY'
+        ];
+        static::assertSame($expectedHeaders, $response->getHeaders());
+    }
+}

--- a/tests/System/Controller/SecuredViewHandlerTest.php
+++ b/tests/System/Controller/SecuredViewHandlerTest.php
@@ -54,13 +54,17 @@ class SecuredViewHandlerTest extends TestCase
         $this->startSymfonyServer($environment);
 
         $response = $this->httpClient->get(
-            '/api/v2/sessions'
+            '/api/v2/sessions',
+            ['base_uri' => $this->getBaseUrl()]
         );
         $expectedHeaders = [
             'X-Content-Type-Options' => 'nosniff',
             'Content-Security-Policy' => "default-src 'none'",
             'X-Frame-Options' => 'DENY'
         ];
-        static::assertSame($expectedHeaders, $response->getHeaders());
+
+        foreach ($expectedHeaders as $key => $value) {
+            static::assertSame([$value], $response->getHeader($key));
+        }
     }
 }


### PR DESCRIPTION
Added security headers such as:
  ```
'X-Content-Type-Options' =>'nosniff',
  'Content-Security-Policy' => "default-src 'none'",
   'X-Frame-Options' => 'DENY'
```
Fix #111 