### PR TITLE
Change the expected subscribers count to fix the test 

### DIFF
--- a/tests/Integration/Controller/ListControllerTest.php
+++ b/tests/Integration/Controller/ListControllerTest.php
@@ -408,6 +408,6 @@ class ListControllerTest extends AbstractControllerTest
         $this->authenticatedJsonRequest('get', '/api/v2/lists/2/subscribers/count');
         $responseContent = $this->getResponseContentAsInt();
 
-        static::assertSame(1, $responseContent);
+        static::assertSame(2, $responseContent);
     }
 }


### PR DESCRIPTION
### Summary
The expected number of subscribers for listid=2 is actually 2
https://github.com/phpList/rest-api/blob/master/tests/Integration/Controller/Fixtures/Subscription.csv

