### PR TITLE
[BUGFIX] Remove the roave/security-advisories dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,7 @@
 
         "phplist/core": "4.0.x-dev",
         "friendsofsymfony/rest-bundle": "^2.3",
-        "sensio/framework-extra-bundle": "5.1.0",
-
-        "roave/security-advisories": "dev-master"
+        "sensio/framework-extra-bundle": "5.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5.6",


### PR DESCRIPTION
1. This dependency should only be a dev dependency, not a production
   dependency, so that is kicks in when we update packages.
2. This package is intended to be used only for projects and distributions,
   not for libraries (like this package).