### PR TITLE
[BUGFIX] Stop caching vendor/ on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ sudo: false
 
 cache:
   directories:
-  - vendor
   - "$HOME/.composer/cache"
 
 before_install:


### PR DESCRIPTION
This resolves problems with incorrect dependencies across
builds.

Caching the Composer cache directory is enough.