### PR TITLE
Add 'extra_data' field to subscribers api to match Subscriber model

### DIFF
--- a/src/Controller/SubscriberController.php
+++ b/src/Controller/SubscriberController.php
@@ -65,6 +65,7 @@ class SubscriberController extends FOSRestController implements ClassResourceInt
      * @OA\JsonContent(
      *           required={"email"},
      * @OA\Property(property="email", type="string", format="string", example="admin"),
+     * @OA\Property(property="extra_data", type="string", format="string", example="extra"),
      * @OA\Property(property="confirmed", type="string", format="boolean", example="eetIc/Gropvoc1"),
      * @OA\Property(property="blacklisted", type="string", format="boolean", example="eetIc/Gropvoc1"),
      * @OA\Property(property="html_entail", type="string", format="boolean", example="eetIc/Gropvoc1"),
@@ -131,6 +132,7 @@ class SubscriberController extends FOSRestController implements ClassResourceInt
 
         $subscriber = new Subscriber();
         $subscriber->setEmail($email);
+        $subscriber->setExtraData($request->get('extra_data'));
         $subscriber->setConfirmed((bool)$request->get('confirmed'));
         $subscriber->setBlacklisted((bool)$request->get('blacklisted'));
         $subscriber->setHtmlEmail((bool)$request->get('html_email'));

--- a/tests/Integration/Controller/SubscriberControllerTest.php
+++ b/tests/Integration/Controller/SubscriberControllerTest.php
@@ -175,8 +175,10 @@ class SubscriberControllerTest extends AbstractControllerTest
         $this->touchDatabaseTable(static::SUBSCRIBER_TABLE_NAME);
 
         $email = 'subscriber@example.com';
+        $extra = 'extra';
         $jsonData = [
             'email' => $email,
+            'extra_data' => $extra,
             'confirmed' => true,
             'blacklisted' => true,
             'html_email' => true,
@@ -188,6 +190,7 @@ class SubscriberControllerTest extends AbstractControllerTest
         $responseContent = $this->getDecodedJsonResponseContent();
 
         static::assertSame($email, $responseContent['email']);
+        static::assertSame($extra, $responseContent['extra_data']);
         static::assertTrue($responseContent['confirmed']);
         static::assertTrue($responseContent['blacklisted']);
         static::assertTrue($responseContent['html_email']);


### PR DESCRIPTION
### Summary

An addition to the subscriber api endpoint to add 'extra_data' as a valid parameter in the json body. This field was a key field missing from the Subscriber model.

### Unit test

Are your changes covered with unit tests, and do they not break anything?

Does not break anything. Unit tests were added.

### Code style

No big code changes. Code style is consistent.

### Other Information

Nothing much, it's a very small change.